### PR TITLE
fix: add bot-blocking domains to .lycheeignore

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,20 @@
 # Intacct domains — auth-walled / rate-limited in CI
 https?://www\.intacct\.com
 https?://preview\.intacct\.com
+https?://dev-us\.intacct\.com
+
+# Sage domains — corporate sites block automated crawlers (403)
+https?://.*\.sage\.com
+https?://.*\.sageintacct\.com
+https?://.*\.sageintacctmpp\.com
+
+# Third-party Sage ecosystem — bot-blocking (403)
+https?://.*\.cloudpayrollengine\.com
+https?://.*\.operix\.com
+https?://developer\.sage\.com
+
+# Dead marketing link (404) in scraped content
+https?://www\.versapay\.com/lp/sage
 
 # Anthropic domains
 https?://claude\.ai


### PR DESCRIPTION
# Pull Request

## Type of change

- [x] Bug fix
- [ ] New feature / enhancement
- [ ] Refactor
- [ ] Documentation
- [x] CI / automation
- [ ] Dependency update

## Components affected

- [ ] `extract.mjs`
- [ ] `summarize.mjs`
- [ ] Generated docs (`docs/`)
- [ ] CI workflows
- [x] Other: `.lycheeignore`

## Motivation

Fixes #3 — The link checker reports 124 errors, nearly all from external sites that block automated crawlers with 403 responses. These are links in scraped release note content that should not be modified.

## What changed

Added exclusion patterns to `.lycheeignore` for:

- **Sage corporate domains** (`sage.com`, `sageintacct.com`, `sageintacctmpp.com`) — return 403 to bots
- **Sage ecosystem** (`cloudpayrollengine.com`, `operix.com`, `developer.sage.com`) — return 403 to bots
- **Internal dev server** (`dev-us.intacct.com`) — unreachable from CI
- **Dead marketing link** (`versapay.com/lp/sage`) — returns 404

## How to test

1. Push triggers the link checker workflow on the PR
2. Verify the 124 errors from issue #3 are resolved
3. Confirm legitimate link checks still run (e.g., GitHub links, docs cross-references)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] Tested with at least one release ID (if applicable)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)