### PR TITLE
fix: audit and correct claude-code-action workflow configurations

### DIFF
--- a/.github/workflows/ci-failure-analysis.yml
+++ b/.github/workflows/ci-failure-analysis.yml
@@ -27,7 +27,11 @@ jobs:
       actions: read
       id-token: write
     steps:
-      - uses: anthropics/claude-code-action@b113f49a56229d8276e2bf05743ad6900121239c # v1.0.45
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -33,9 +33,10 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - uses: anthropics/claude-code-action@b113f49a56229d8276e2bf05743ad6900121239c # v1.0.45
+      - uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           prompt: |
             Review this pull request. Read the diff, then run linters on any changed source files.
 
@@ -45,7 +46,7 @@ jobs:
             3. If .md files changed (excluding docs/): npx markdownlint-cli2 '*.md' '.github/**/*.md' '#node_modules' '#.claude' '#docs'
             4. Run: npm run format:check
 
-            Post a review comment with this structure:
+            Format your response with this structure:
             ## Summary
             One-paragraph summary of what this PR does.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,9 +52,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
-      - uses: anthropics/claude-code-action@b113f49a56229d8276e2bf05743ad6900121239c # v1.0.45
+      - uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
-          assignee_trigger: true
+          assignee_trigger: "claude"
           claude_args: '--allowedTools "Bash(npm run lint),Bash(npm run format:check),Read,Glob,Grep"'

--- a/.github/workflows/semantic-labeler.yml
+++ b/.github/workflows/semantic-labeler.yml
@@ -29,13 +29,13 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: anthropics/claude-code-action@b113f49a56229d8276e2bf05743ad6900121239c # v1.0.45
+      - uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Analyze this GitHub issue and apply appropriate labels using the gh CLI.
 
-            Issue #${{ github.event.issue.number }}: "${{ github.event.issue.title }}"
+            Issue #${{ github.event.issue.number }}: ${{ toJSON(github.event.issue.title) }}
             Body: ${{ toJSON(github.event.issue.body) }}
 
             Available label categories:
@@ -71,13 +71,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: anthropics/claude-code-action@b113f49a56229d8276e2bf05743ad6900121239c # v1.0.45
+      - uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Analyze this pull request and apply appropriate labels using the gh CLI.
 
-            PR #${{ github.event.pull_request.number }}: "${{ github.event.pull_request.title }}"
+            PR #${{ github.event.pull_request.number }}: ${{ toJSON(github.event.pull_request.title) }}
             Body: ${{ toJSON(github.event.pull_request.body) }}
 
             First, read the diff:


### PR DESCRIPTION
- claude.yml: fix assignee_trigger from boolean `true` to username
  string `"claude"` (action expects a username, not a boolean; the
  string "true" never matches any assignee, breaking assignment triggers)
- claude-pr-review.yml: add `use_sticky_comment: true` to update a
  single comment instead of creating new ones on each push; fix prompt
  wording from "Post a review comment" to "Format your response" since
  the action handles comment posting automatically
- ci-failure-analysis.yml: add missing checkout step so Claude has
  access to project context (CLAUDE.md, code files) for better analysis
- semantic-labeler.yml: wrap issue and PR titles in toJSON() to match
  the body fields and prevent YAML injection / prompt injection from
  crafted titles
- All workflows: bump claude-code-action from v1.0.45 to v1.0.46

https://claude.ai/code/session_01CVANyo57kE5ghaHZmYpxCj